### PR TITLE
Fix NPE issue for MethodChannel

### DIFF
--- a/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
+++ b/android/src/main/java/com/clevertap/clevertap_plugin/CleverTapPlugin.java
@@ -1085,6 +1085,10 @@ public class CleverTapPlugin implements ActivityAware,
 
     private void invokeMethodOnUiThread(final String methodName, final String cleverTapID) {
         final MethodChannel channel = this.channel;
+        if (channel == null) {
+            Log.d(TAG, "methodChannel in invokeMethodOnUiThread(String) is null");
+            return;
+        }
         runOnMainThread(() -> {
             if (!cleverTapID.isEmpty()) {
                 channel.invokeMethod(methodName, cleverTapID);
@@ -1096,12 +1100,20 @@ public class CleverTapPlugin implements ActivityAware,
 
     private void invokeMethodOnUiThread(final String methodName, final Map map) {
         final MethodChannel channel = this.channel;
+        if (channel == null) {
+            Log.d(TAG, "methodChannel in invokeMethodOnUiThread(Map) is null");
+            return;
+        }
         runOnMainThread(() -> channel.invokeMethod(methodName, map));
     }
 
     @SuppressWarnings("SameParameterValue")
     private void invokeMethodOnUiThread(final String methodName, final ArrayList list) {
         final MethodChannel channel = this.channel;
+        if (channel == null) {
+            Log.d(TAG, "methodChannel in invokeMethodOnUiThread(ArrayList) is null");
+            return;
+        }
         runOnMainThread(() -> channel.invokeMethod(methodName, list));
     }
 


### PR DESCRIPTION
When device state goes to background, the MethodChannel becomes null. So, we need to add null check on MethodChannel before invoking method on UI thread.

Crashlytics reference : https://console.firebase.google.com/u/0/project/nurture-farm/crashlytics/app/android:nurture.farm/issues/ec3b0503bef0dcddb27548be3be6a898?time=last-seven-days&sessionEventKey=61EA185C00C0000179B29149EE45AB3F_1633924362855253550